### PR TITLE
fix for pypy build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,10 @@ source:
   sha256: dd1cd0112d09cea29afa1568d644f54eccffdad2f5909708b519c1d7c647e9f1
   patches:
     - findjpeg.patch
+    - realpath.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipe/realpath.patch
+++ b/recipe/realpath.patch
@@ -1,0 +1,37 @@
+diff --git a/python/__init__.py b/python/__init__.py
+index 2ade041..cc68cd6 100644
+--- a/python/__init__.py
++++ b/python/__init__.py
+@@ -2237,20 +2237,18 @@ def _get_c_library_filename():
+     else:
+         library_name = "libcoda.so"
+ 
+-    # check for library file in the parent directory (for pyinstaller bundles)
+-    library_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", library_name))
+-    if os.path.exists(library_path):
+-        return library_path
+-
+-    # assume the library to be in the parent library directory
+-    library_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../..", library_name))
+-    if not os.path.exists(library_path):
+-        # on RHEL the python path uses lib64, but the library might have gotten installed in lib
+-        alt_library_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../../../lib", library_name))
+-        if os.path.exists(alt_library_path):
+-            return alt_library_path
+-    return library_path
+-
++    # expand symlinks (for conda-forge, pypy build)
++    dirname = os.path.dirname(os.path.realpath(__file__))
++
++    # look in different directories based on platform
++    for rel_path in (
++        '..', # pyinstaller bundles
++        '../../..', # regular lib dir
++        '../../../../lib', # on RHEL the python path uses lib64, but the library might have gotten installed in lib
++    ):
++        library_path = os.path.normpath(os.path.join(dirname, rel_path, library_name))
++        if os.path.exists(library_path):
++            return library_path
+ 
+ #
+ # UTILITY FUNCTIONS


### PR DESCRIPTION
for some reason, coda.__file__ contains a symlink part,
breaking the code locating libcoda.so.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
